### PR TITLE
Fix group_authority representation in repr

### DIFF
--- a/aarc_g002_entitlement/__init__.py
+++ b/aarc_g002_entitlement/__init__.py
@@ -130,13 +130,14 @@ class Aarc_g002_entitlement:
 
         return ((
             'urn:{namespace_id}:{delegated_namespace}{subnamespaces}' +
-            ':group:{group}{subgroups}{role}' +
-            '#{group_authority}'
+            ':group:{group}{subgroups}{role}{group_authority}'
         ).format(**{
                 'namespace_id': self.namespace_id,
                 'delegated_namespace': self.delegated_namespace,
                 'group': self.group,
-                'group_authority': self.group_authority,
+                'group_authority': (
+                    '#{}'.format(self.group_authority) if self.group_authority else ''
+                ),
                 'subnamespaces': ''.join([':{}'.format(ns) for ns in self.subnamespaces]),
                 'subgroups': ''.join([':{}'.format(grp) for grp in self.subgroups]),
                 'role': ':role={}'.format(self.role) if self.role else ''


### PR DESCRIPTION
The current `__repr__` implementation of `Aarc_g002_entitlement` is assuming that the `group_authority` is always defined and present. However, this is not always the case. In the cases that the `group_authority` is not defined `#None` will be displayed as a suffix of the `repr` result. To fix this, we check whether `group_authority` is defined and only if that condition is met we display it, exactly as is already done with `role`.

---

Before the change

```py
In [1]: from aarc_g002_entitlement import Aarc_g002_entitlement

In [2]: ent = Aarc_g002_entitlement("urn:ns_id:ns_del:group:group_name", strict=False)

In [3]: repr(ent)
Out[3]: 'urn:ns_id:ns_del:group:group_name#None'
```

After the change

```py
In [1]: from aarc_g002_entitlement import Aarc_g002_entitlement

In [2]: ent = Aarc_g002_entitlement("urn:ns_id:ns_del:group:group_name", strict=False)

In [3]: repr(ent)
Out[3]: 'urn:ns_id:ns_del:group:group_name'
```