### PR TITLE
Fix subnamespaces and subgroups comparison 

### DIFF
--- a/aarc_g002_entitlement/__init__.py
+++ b/aarc_g002_entitlement/__init__.py
@@ -243,10 +243,7 @@ class Aarc_g002_entitlement:
         is_equal = (
             self.namespace_id == other.namespace_id
             and self.delegated_namespace == other.delegated_namespace
-            and all(
-                subnamespace in other.subnamespaces
-                for subnamespace in self.subnamespaces
-            )
+            and self.subnamespaces == other.subnamespaces
             and self.group == other.group
             and self.subgroups == other.subgroups
             and self.role == other.role
@@ -277,19 +274,19 @@ class Aarc_g002_entitlement:
         except IndexError:
             other_subgroup_for_role = None
 
+        other_subns_len = len(other.subnamespaces)
+        other_subgroups_len = len(other.subgroups)
         is_le = (
             self.namespace_id == other.namespace_id
             and self.delegated_namespace == other.delegated_namespace
             and all(
-                subnamespace in other.subnamespaces
-                for subnamespace in self.subnamespaces
+                other_subns_len > idx and subns == other.subnamespaces[idx]
+                for idx, subns in enumerate(self.subnamespaces)
             )
             and self.group == other.group
-            and (
-                all(
-                    subgroup in other.subgroups
-                    for subgroup in self.subgroups
-                )
+            and all(
+                other_subgroups_len > idx and subgroup == other.subgroups[idx]
+                for idx, subgroup in enumerate(self.subgroups)
             )
             and (
                 self.role == other.role

--- a/aarc_g002_entitlement/test_entitlement.py
+++ b/aarc_g002_entitlement/test_entitlement.py
@@ -9,12 +9,44 @@ from aarc_g002_entitlement import Aarc_g002_entitlement_ParseError
 
 class TestAarc_g002_entitlement:
     def test_equality(self):
-        required_group = "urn:geant:h-df.de:group:aai-admin:role = member#unity.helmholtz-data-federation.de"
-        actual_group   = "urn:geant:h-df.de:group:aai-admin:role = member#unity.helmholtz-data-federation.de"
+        required_group = "urn:geant:h-df.de:group:aai-admin:role=member#unity.helmholtz-data-federation.de"
+        actual_group   = "urn:geant:h-df.de:group:aai-admin:role=member#unity.helmholtz-data-federation.de"
         req_entitlement = Aarc_g002_entitlement(required_group)
         act_entitlement = Aarc_g002_entitlement(actual_group)
         assert act_entitlement == req_entitlement
         assert req_entitlement.is_contained_in(act_entitlement)
+
+    def test_order_of_subnamespaces_equality(self):
+        required_group = "urn:geant:h-df.de:subns1:subns2:group:aai-admin:role=member#unity.helmholtz-data-federation.de"
+        actual_group   = "urn:geant:h-df.de:subns2:subns1:group:aai-admin:role=member#unity.helmholtz-data-federation.de"
+        req_entitlement = Aarc_g002_entitlement(required_group)
+        act_entitlement = Aarc_g002_entitlement(actual_group)
+        assert act_entitlement != req_entitlement
+        assert not req_entitlement.is_contained_in(act_entitlement)
+
+    def test_order_of_subgroups_equality(self):
+        required_group = "urn:geant:h-df.de:group:aai-admin:subgroup1:subgroup2:subgroup3:role=member#unity.helmholtz-data-federation.de"
+        actual_group   = "urn:geant:h-df.de:group:aai-admin:subgroup2:subgroup1:subgroup3:role=member#unity.helmholtz-data-federation.de"
+        req_entitlement = Aarc_g002_entitlement(required_group)
+        act_entitlement = Aarc_g002_entitlement(actual_group)
+        assert act_entitlement != req_entitlement
+        assert not req_entitlement.is_contained_in(act_entitlement)
+
+    def test_order_of_subnamespaces_out_of_bounds_equality(self):
+        required_group = "urn:geant:h-df.de:subns1:subns2:subns0:group:aai-admin:role=member#unity.helmholtz-data-federation.de"
+        actual_group   = "urn:geant:h-df.de:subns1:subns2:group:aai-admin:role=member#unity.helmholtz-data-federation.de"
+        req_entitlement = Aarc_g002_entitlement(required_group)
+        act_entitlement = Aarc_g002_entitlement(actual_group)
+        assert act_entitlement != req_entitlement
+        assert not req_entitlement.is_contained_in(act_entitlement)
+
+    def test_order_of_subgroups_out_of_bounds_equality(self):
+        required_group = "urn:geant:h-df.de:group:aai-admin:subgroup1:subgroup2:subgroup3:role=member#unity.helmholtz-data-federation.de"
+        actual_group   = "urn:geant:h-df.de:group:aai-admin:subgroup1:subgroup2:role=member#unity.helmholtz-data-federation.de"
+        req_entitlement = Aarc_g002_entitlement(required_group)
+        act_entitlement = Aarc_g002_entitlement(actual_group)
+        assert act_entitlement != req_entitlement
+        assert not req_entitlement.is_contained_in(act_entitlement)
 
     def test_simple(self):
         required_group = "urn:geant:h-df.de:group:aai-admin:role=member#unity.helmholtz-data-federation.de"


### PR DESCRIPTION
We can have multiple subnamespaces and subgroups in entitlements. When comparing between entitlements it is not enough to check that they are all present, but the order must be the same. The added test cases show how this manifests.